### PR TITLE
Fixes from Abdelrahman advices

### DIFF
--- a/main.dart
+++ b/main.dart
@@ -1,14 +1,15 @@
-import 'dart:async';
 import 'dart:io';
 
 class Token {
-  String value;
-  int start;
-  int end;
-  int type = null;
-  bool isFaulty;
-
-  Token(this.value, this.start, this.end, {this.isFaulty}) {}
+  final String value;
+  final int start;
+  final int end;
+  final int type = null;
+  final bool isFaulty;
+  String toString(){
+    return 'Token "${value == '\n' ? '\\n' : value}", ${start}–${end}';
+  }
+  const Token(this.value, this.start, this.end, {this.isFaulty});
 }
 
 RegExp langTokenPtn = new RegExp(
@@ -16,13 +17,13 @@ RegExp langTokenPtn = new RegExp(
   multiLine: true,
 );
 
-Future<List<Token>> lexer(path) async {
+List<Token> lexer(path){
   var tokens = <Token>[];
-  var fileContents = await new File(path).readAsString();
-  var matches = langTokenPtn.allMatches(fileContents);
-  var previousMatch = null;
+  var fileContents = new File(path).readAsStringSync();
+  Iterable<RegExpMatch> iterator = langTokenPtn.allMatches(fileContents);
 
-  for (var match in matches) {
+  RegExpMatch previousMatch = null;
+  for (RegExpMatch match in iterator) {
     if (previousMatch != null && previousMatch.end != match.start) {
       tokens.add(new Token(
         fileContents.substring(previousMatch.end, match.start),
@@ -31,24 +32,21 @@ Future<List<Token>> lexer(path) async {
         isFaulty: true,
       ));
     }
-
     tokens.add(new Token(
       match.group(1),
       match.start,
       match.end,
       isFaulty: false,
     ));
-
     previousMatch = match;
   }
 
   return tokens;
 }
 
-void main() async {
-  List<Token> tokensList = await lexer('./tests/bubble_sort.isc');
+void main(){
+  List<Token> tokensList = lexer('./tests/bubble_sort.isc');
   tokensList.forEach((element) {
-    print(
-        'Token "${element.value == '\n' ? '\\n' : element.value}", ${element.start}–${element.end}');
+    print(element);
   });
 }

--- a/main.dart
+++ b/main.dart
@@ -4,49 +4,45 @@ class Token {
   final String value;
   final int start;
   final int end;
-  final int type = null;
   final bool isFaulty;
-  String toString(){
+
+  String toString() {
     return 'Token "${value == '\n' ? '\\n' : value}", ${start}–${end}';
   }
+
   const Token(this.value, this.start, this.end, {this.isFaulty});
 }
 
-RegExp langTokenPtn = new RegExp(
-  "([a-zA-Z_]\\w*|[0-9.]|[:;(),\\[\\]=.<>\/*%+\n-])",
+RegExp langTokenPtn = RegExp(
+  "([a-zA-Z_]\\w*|[0-9]+(?:\\.[0-9]*)?|[:;(),\\[\\]=.<>\/*%+\n-])",
   multiLine: true,
 );
+RegExp allWhitespacePtn = RegExp("^\\s+\$");
 
-List<Token> lexer(path){
-  var tokens = <Token>[];
-  var fileContents = new File(path).readAsStringSync();
-  Iterable<RegExpMatch> iterator = langTokenPtn.allMatches(fileContents);
-
+Iterable<Token> lexer(String sourceCode) sync* {
   RegExpMatch previousMatch = null;
-  for (RegExpMatch match in iterator) {
+  for (var match in langTokenPtn.allMatches(sourceCode)) {
     if (previousMatch != null && previousMatch.end != match.start) {
-      tokens.add(new Token(
-        fileContents.substring(previousMatch.end, match.start),
+      var tokenValue = sourceCode.substring(previousMatch.end, match.start);
+      yield Token(
+        tokenValue,
         previousMatch.end,
         match.start,
-        isFaulty: true,
-      ));
+        isFaulty: !allWhitespacePtn.hasMatch(tokenValue),
+      );
     }
-    tokens.add(new Token(
+
+    yield Token(
       match.group(1),
       match.start,
       match.end,
       isFaulty: false,
-    ));
+    );
+
     previousMatch = match;
   }
-
-  return tokens;
 }
 
-void main(){
-  List<Token> tokensList = lexer('./tests/bubble_sort.isc');
-  tokensList.forEach((element) {
-    print(element);
-  });
+void main() {
+  lexer(File('./tests/bubble_sort.isc').readAsStringSync()).forEach(print);
 }


### PR DESCRIPTION
- Everything in the token class is only assigned once (when constructing), so it can be changed to a const constructor (with const members of course), which means more compile-time optimization.
DONE

- Use the readAsStringSync variant to avoid making every function async.
DONE

- previousMatch (line 23) has the type dynamic since it is initialize to null and declared using var. This is not a good practice in Dart.
DONE

- Define toString on the Token class so that print can use it automatically.
DONE

- consider using a generator function instead of returning a Future with all tokens at once to be more memory-efficient when parsing.
DONE

- advice: prepare for the null-safety update by opting in from now.
NOT DONE