### PR TITLE
Semantic checking beginnings

### DIFF
--- a/ast-nodes/add-operator.dart
+++ b/ast-nodes/add-operator.dart
@@ -12,4 +12,8 @@ class AddOperator extends BinaryRelation implements Sum {
 
   AddOperator(Expression leftOperand, Expression rightOperand)
     : super(leftOperand, rightOperand);
+
+  void checkSemantics() {
+    // TODO: implement
+  }
 }

--- a/ast-nodes/add-operator.dart
+++ b/ast-nodes/add-operator.dart
@@ -1,11 +1,15 @@
 import 'sum.dart';
 import 'binary-relation.dart';
 import 'expression.dart';
+import 'var-type.dart';
 
 /// Numeric addition operator.
 ///
 /// Casts both operands to a numeric type and returns a numeric value.
 class AddOperator extends BinaryRelation implements Sum {
+  VarType resultType;
+  bool isConstant;
+
   AddOperator(Expression leftOperand, Expression rightOperand)
     : super(leftOperand, rightOperand);
 }

--- a/ast-nodes/and-operator.dart
+++ b/ast-nodes/and-operator.dart
@@ -12,4 +12,8 @@ class AndOperator extends BinaryRelation {
 
   AndOperator(Expression leftOperand, Expression rightOperand)
     : super(leftOperand, rightOperand);
+
+  void checkSemantics() {
+    // TODO: implement
+  }
 }

--- a/ast-nodes/and-operator.dart
+++ b/ast-nodes/and-operator.dart
@@ -1,10 +1,15 @@
 import 'binary-relation.dart';
 import 'expression.dart';
+import 'boolean-type.dart';
+import 'var-type.dart';
 
 /// Logical AND operator.
 ///
 /// Casts both operands to `boolean` and returns a `boolean` value.
 class AndOperator extends BinaryRelation {
+  VarType resultType = BooleanType();
+  bool isConstant;
+
   AndOperator(Expression leftOperand, Expression rightOperand)
     : super(leftOperand, rightOperand);
 }

--- a/ast-nodes/array-type.dart
+++ b/ast-nodes/array-type.dart
@@ -44,7 +44,7 @@ class ArrayType implements VarType {
 
   void propagateScopeMark(ScopeElement parentMark) {
     this.scopeMark = parentMark;
-    this.size.propagateScopeMark(parentMark);
+    this.size?.propagateScopeMark(parentMark);
     this.elementType.propagateScopeMark(parentMark);
   }
 

--- a/ast-nodes/array-type.dart
+++ b/ast-nodes/array-type.dart
@@ -1,8 +1,10 @@
 import 'var-type.dart';
 import 'expression.dart';
+import 'integer-type.dart';
 import '../print-utils.dart';
 import '../iterator-utils.dart';
 import '../lexer.dart';
+import '../semantic-error.dart';
 import '../symbol-table/scope-element.dart';
 
 /// An array type with optional [size].
@@ -44,5 +46,16 @@ class ArrayType implements VarType {
     this.scopeMark = parentMark;
     this.size.propagateScopeMark(parentMark);
     this.elementType.propagateScopeMark(parentMark);
+  }
+
+  void checkSemantics() {
+    this.size.checkSemantics();
+    if (!this.size.isConstant) {
+      throw SemanticError(this.size, 'The array size must be a constant expression');
+    }
+    if (this.size.resultType is! IntegerType) {
+      throw SemanticError(this.size, 'The array size must be integer');
+    }
+    this.elementType.checkSemantics();
   }
 }

--- a/ast-nodes/array-type.dart
+++ b/ast-nodes/array-type.dart
@@ -3,9 +3,12 @@ import 'expression.dart';
 import '../print-utils.dart';
 import '../iterator-utils.dart';
 import '../lexer.dart';
+import '../symbol-table/scope-element.dart';
 
 /// An array type with optional [size].
 class ArrayType implements VarType {
+  ScopeElement scopeMark;
+
   Expression size;
   VarType elementType;
 
@@ -35,5 +38,11 @@ class ArrayType implements VarType {
       + (this.size?.toString(depth: depth + 1, prefix: 'size: ') ?? '')
       + (this.elementType?.toString(depth: depth + 1, prefix: 'element type: ') ?? '')
     );
+  }
+
+  void propagateScopeMark(ScopeElement parentMark) {
+    this.scopeMark = parentMark;
+    this.size.propagateScopeMark(parentMark);
+    this.elementType.propagateScopeMark(parentMark);
   }
 }

--- a/ast-nodes/assignment.dart
+++ b/ast-nodes/assignment.dart
@@ -5,11 +5,12 @@ import '../print-utils.dart';
 import '../lexer.dart';
 import '../iterator-utils.dart';
 import '../syntax-error.dart';
-
-
+import '../symbol-table/scope-element.dart';
 
 /// An assignment of the value on the right hand side ([rhs]) to the left hand side ([lhs]).
 class Assignment implements Statement {
+  ScopeElement scopeMark;
+
   ModifiablePrimary lhs;
   Expression rhs;
 
@@ -34,5 +35,11 @@ class Assignment implements Statement {
       + (this.lhs?.toString(depth: depth + 1, prefix: 'lhs: ') ?? '')
       + (this.rhs?.toString(depth: depth + 1, prefix: 'rhs: ') ?? '')
     );
+  }
+
+  void propagateScopeMark(ScopeElement parentMark) {
+    this.scopeMark = parentMark;
+    this.lhs.propagateScopeMark(parentMark);
+    this.rhs.propagateScopeMark(parentMark);
   }
 }

--- a/ast-nodes/assignment.dart
+++ b/ast-nodes/assignment.dart
@@ -42,4 +42,8 @@ class Assignment implements Statement {
     this.lhs.propagateScopeMark(parentMark);
     this.rhs.propagateScopeMark(parentMark);
   }
+
+  void checkSemantics() {
+    // TODO: implement
+  }
 }

--- a/ast-nodes/binary-relation.dart
+++ b/ast-nodes/binary-relation.dart
@@ -1,8 +1,11 @@
 import 'expression.dart';
 import '../print-utils.dart';
+import '../symbol-table/scope-element.dart';
 
 /// An abstract binary relation with two operands.
 abstract class BinaryRelation implements Expression {
+  ScopeElement scopeMark;
+
   Expression leftOperand;
   Expression rightOperand;
 
@@ -14,5 +17,11 @@ abstract class BinaryRelation implements Expression {
       + (this.leftOperand?.toString(depth: depth + 1, prefix: 'left operand: ') ?? '')
       + (this.rightOperand?.toString(depth: depth + 1, prefix: 'right operand: ') ?? '')
     );
+  }
+
+  void propagateScopeMark(ScopeElement parentMark) {
+    this.scopeMark = parentMark;
+    this.leftOperand.propagateScopeMark(parentMark);
+    this.rightOperand.propagateScopeMark(parentMark);
   }
 }

--- a/ast-nodes/boolean-literal.dart
+++ b/ast-nodes/boolean-literal.dart
@@ -21,4 +21,8 @@ class BooleanLiteral implements Primary {
   void propagateScopeMark(ScopeElement parentMark) {
     this.scopeMark = parentMark;
   }
+
+  void checkSemantics() {
+    // TODO: implement
+  }
 }

--- a/ast-nodes/boolean-literal.dart
+++ b/ast-nodes/boolean-literal.dart
@@ -1,13 +1,20 @@
 import 'primary.dart';
 import '../print-utils.dart';
+import '../symbol-table/scope-element.dart';
 
 /// A literal boolean value in code.
 class BooleanLiteral implements Primary {
+  ScopeElement scopeMark;
+
   bool value;
 
   BooleanLiteral(this.value);
 
   String toString({int depth = 0, String prefix = ''}) {
     return drawDepth('${prefix}BooleanLiteral(${this.value})', depth);
+  }
+
+  void propagateScopeMark(ScopeElement parentMark) {
+    this.scopeMark = parentMark;
   }
 }

--- a/ast-nodes/boolean-literal.dart
+++ b/ast-nodes/boolean-literal.dart
@@ -1,9 +1,13 @@
 import 'primary.dart';
+import 'boolean-type.dart';
+import 'var-type.dart';
 import '../print-utils.dart';
 import '../symbol-table/scope-element.dart';
 
 /// A literal boolean value in code.
 class BooleanLiteral implements Primary {
+  VarType resultType = BooleanType();
+  bool isConstant = true;
   ScopeElement scopeMark;
 
   bool value;

--- a/ast-nodes/boolean-type.dart
+++ b/ast-nodes/boolean-type.dart
@@ -15,4 +15,6 @@ class BooleanType implements VarType {
   void propagateScopeMark(ScopeElement parentMark) {
     this.scopeMark = parentMark;
   }
+
+  void checkSemantics() {}
 }

--- a/ast-nodes/boolean-type.dart
+++ b/ast-nodes/boolean-type.dart
@@ -1,11 +1,18 @@
 import 'var-type.dart';
 import '../print-utils.dart';
+import '../symbol-table/scope-element.dart';
 
 /// The built-in boolean type.
 class BooleanType implements VarType {
+  ScopeElement scopeMark;
+
   BooleanType();
 
   String toString({int depth = 0, String prefix = ''}) {
     return drawDepth('${prefix}BooleanType', depth);
+  }
+
+  void propagateScopeMark(ScopeElement parentMark) {
+    this.scopeMark = parentMark;
   }
 }

--- a/ast-nodes/div-operator.dart
+++ b/ast-nodes/div-operator.dart
@@ -1,11 +1,15 @@
 import 'product.dart';
 import 'binary-relation.dart';
 import 'expression.dart';
+import 'var-type.dart';
 
 /// Numeric division operator.
 ///
 /// Casts both operands to a numeric type and returns a numeric value.
 class DivOperator extends BinaryRelation implements Product {
+  VarType resultType;
+  bool isConstant;
+
   DivOperator(Expression leftOperand, Expression rightOperand)
     : super(leftOperand, rightOperand);
 }

--- a/ast-nodes/div-operator.dart
+++ b/ast-nodes/div-operator.dart
@@ -12,4 +12,8 @@ class DivOperator extends BinaryRelation implements Product {
 
   DivOperator(Expression leftOperand, Expression rightOperand)
     : super(leftOperand, rightOperand);
+
+  void checkSemantics() {
+    // TODO: implement
+  }
 }

--- a/ast-nodes/eq-operator.dart
+++ b/ast-nodes/eq-operator.dart
@@ -13,4 +13,8 @@ class EqOperator extends BinaryRelation implements Comparison {
 
   EqOperator(Expression leftOperand, Expression rightOperand)
     : super(leftOperand, rightOperand);
+
+  void checkSemantics() {
+    // TODO: implement
+  }
 }

--- a/ast-nodes/eq-operator.dart
+++ b/ast-nodes/eq-operator.dart
@@ -1,11 +1,16 @@
 import 'comparison.dart';
 import 'binary-relation.dart';
 import 'expression.dart';
+import 'boolean-type.dart';
+import 'var-type.dart';
 
 /// Universal _equal to_ operator.
 ///
 /// Requires both operands to be of the same type.
 class EqOperator extends BinaryRelation implements Comparison {
+  VarType resultType = BooleanType();
+  bool isConstant;
+
   EqOperator(Expression leftOperand, Expression rightOperand)
     : super(leftOperand, rightOperand);
 }

--- a/ast-nodes/expression.dart
+++ b/ast-nodes/expression.dart
@@ -7,6 +7,9 @@ import '../syntax-error.dart';
 
 /// An abstract expression that returns a value.
 abstract class Expression implements Statement {
+  VarType resultType;
+  bool isConstant;
+
   factory Expression.parse(Iterable<Token> tokens) {
     var iterator = tokens.iterator;
 

--- a/ast-nodes/field-access.dart
+++ b/ast-nodes/field-access.dart
@@ -1,5 +1,6 @@
 import 'modifiable-primary.dart';
 import '../print-utils.dart';
+import '../symbol-table/scope-element.dart';
 
 /// A record field access by [name] – for either reading or writing.
 ///
@@ -9,6 +10,8 @@ import '../print-utils.dart';
 /// FieldAccess("c", FieldAccess("b", Variable("a")))
 /// ```
 class FieldAccess implements ModifiablePrimary {
+  ScopeElement scopeMark;
+
   String name;
   ModifiablePrimary object;
 
@@ -19,5 +22,10 @@ class FieldAccess implements ModifiablePrimary {
       drawDepth('${prefix}FieldAccess("${this.name}")', depth)
       + (this.object?.toString(depth: depth + 1, prefix: 'object: ') ?? '')
     );
+  }
+
+  void propagateScopeMark(ScopeElement parentMark) {
+    this.scopeMark = parentMark;
+    this.object.propagateScopeMark(parentMark);
   }
 }

--- a/ast-nodes/field-access.dart
+++ b/ast-nodes/field-access.dart
@@ -31,4 +31,8 @@ class FieldAccess implements ModifiablePrimary {
     this.scopeMark = parentMark;
     this.object.propagateScopeMark(parentMark);
   }
+
+  void checkSemantics() {
+    // TODO: implement
+  }
 }

--- a/ast-nodes/field-access.dart
+++ b/ast-nodes/field-access.dart
@@ -1,4 +1,5 @@
 import 'modifiable-primary.dart';
+import 'var-type.dart';
 import '../print-utils.dart';
 import '../symbol-table/scope-element.dart';
 
@@ -10,6 +11,8 @@ import '../symbol-table/scope-element.dart';
 /// FieldAccess("c", FieldAccess("b", Variable("a")))
 /// ```
 class FieldAccess implements ModifiablePrimary {
+  VarType resultType;
+  bool isConstant;
   ScopeElement scopeMark;
 
   String name;

--- a/ast-nodes/for-loop.dart
+++ b/ast-nodes/for-loop.dart
@@ -84,4 +84,8 @@ class ForLoop implements Statement, ScopeCreator {
       }
     }
   }
+
+  void checkSemantics() {
+    // TODO: implement
+  }
 }

--- a/ast-nodes/greater-eq-operator.dart
+++ b/ast-nodes/greater-eq-operator.dart
@@ -1,11 +1,16 @@
 import 'comparison.dart';
 import 'binary-relation.dart';
 import 'expression.dart';
+import 'boolean-type.dart';
+import 'var-type.dart';
 
 /// Numeric _greater than or equal to_ operator.
 ///
 /// Casts both operands to a numeric type and returns a boolean value.
 class GreaterEqOperator extends BinaryRelation implements Comparison {
+  VarType resultType = BooleanType();
+  bool isConstant;
+
   GreaterEqOperator(Expression leftOperand, Expression rightOperand)
     : super(leftOperand, rightOperand);
 }

--- a/ast-nodes/greater-eq-operator.dart
+++ b/ast-nodes/greater-eq-operator.dart
@@ -13,4 +13,8 @@ class GreaterEqOperator extends BinaryRelation implements Comparison {
 
   GreaterEqOperator(Expression leftOperand, Expression rightOperand)
     : super(leftOperand, rightOperand);
+
+  void checkSemantics() {
+    // TODO: implement
+  }
 }

--- a/ast-nodes/greater-operator.dart
+++ b/ast-nodes/greater-operator.dart
@@ -1,11 +1,16 @@
 import 'comparison.dart';
 import 'binary-relation.dart';
 import 'expression.dart';
+import 'boolean-type.dart';
+import 'var-type.dart';
 
 /// Numeric _greater than_ operator.
 ///
 /// Casts both operands to a numeric type and returns a boolean value.
 class GreaterOperator extends BinaryRelation implements Comparison {
+  VarType resultType = BooleanType();
+  bool isConstant;
+
   GreaterOperator(Expression leftOperand, Expression rightOperand)
     : super(leftOperand, rightOperand);
 }

--- a/ast-nodes/greater-operator.dart
+++ b/ast-nodes/greater-operator.dart
@@ -13,4 +13,8 @@ class GreaterOperator extends BinaryRelation implements Comparison {
 
   GreaterOperator(Expression leftOperand, Expression rightOperand)
     : super(leftOperand, rightOperand);
+
+  void checkSemantics() {
+    // TODO: implement
+  }
 }

--- a/ast-nodes/if-statement.dart
+++ b/ast-nodes/if-statement.dart
@@ -80,7 +80,7 @@ class IfStatement implements Statement, ScopeCreator {
   void propagateScopeMark(ScopeElement parentMark) {
     this.scopeMark = parentMark;
     this.condition.propagateScopeMark(parentMark);
-    
+
     var scopeTrue = Scope();
     var scopeFalse = Scope();
     this.scopes = [scopeTrue, scopeFalse];
@@ -100,5 +100,9 @@ class IfStatement implements Statement, ScopeCreator {
         }
       }
     }
+  }
+
+  void checkSemantics() {
+    // TODO: implement
   }
 }

--- a/ast-nodes/if-statement.dart
+++ b/ast-nodes/if-statement.dart
@@ -1,12 +1,19 @@
 import 'statement.dart';
 import 'expression.dart';
+import 'declaration.dart';
+import 'scope-creator.dart';
 import '../print-utils.dart';
 import '../iterator-utils.dart';
 import '../lexer.dart';
 import '../syntax-error.dart';
+import '../symbol-table/scope.dart';
+import '../symbol-table/scope-element.dart';
 
 /// A conditional statement.
-class IfStatement implements Statement {
+class IfStatement implements Statement, ScopeCreator {
+  ScopeElement scopeMark;
+  List<Scope> scopes;
+
   Expression condition;
   List<Statement> blockTrue;
   List<Statement> blockFalse;
@@ -68,5 +75,30 @@ class IfStatement implements Statement {
       + drawDepth('false block:', depth + 1)
       + this.blockFalse.map((node) => node?.toString(depth: depth + 2) ?? '').join('')
     );
+  }
+
+  void propagateScopeMark(ScopeElement parentMark) {
+    this.scopeMark = parentMark;
+    this.condition.propagateScopeMark(parentMark);
+    
+    var scopeTrue = Scope();
+    var scopeFalse = Scope();
+    this.scopes = [scopeTrue, scopeFalse];
+    var bodies = <List<Statement>>[this.blockTrue, this.blockFalse];
+
+    for (var i = 0; i < bodies.length; ++i) {
+      ScopeElement currentMark = this.scopes[i].lastChild;
+      for (var statement in bodies[i]) {
+        statement.propagateScopeMark(currentMark);
+        if (statement is Declaration) {
+          currentMark = this.scopes[i].addDeclaration(statement);
+        }
+        if (statement is ScopeCreator) {
+          (statement as ScopeCreator).scopes.forEach(
+            (subscope) => this.scopes[i].addSubscope(subscope)
+          );
+        }
+      }
+    }
   }
 }

--- a/ast-nodes/index-access.dart
+++ b/ast-nodes/index-access.dart
@@ -38,4 +38,8 @@ class IndexAccess implements ModifiablePrimary {
     this.index.propagateScopeMark(parentMark);
     this.object.propagateScopeMark(parentMark);
   }
+
+  void checkSemantics() {
+    // TODO: implement
+  }
 }

--- a/ast-nodes/index-access.dart
+++ b/ast-nodes/index-access.dart
@@ -1,6 +1,7 @@
 import 'modifiable-primary.dart';
 import 'expression.dart';
 import '../print-utils.dart';
+import '../symbol-table/scope-element.dart';
 
 /// An array element access by [index] – for either reading or writing.
 ///
@@ -16,6 +17,8 @@ import '../print-utils.dart';
 /// )
 /// ```
 class IndexAccess implements ModifiablePrimary {
+  ScopeElement scopeMark;
+
   Expression index;
   ModifiablePrimary object;
 
@@ -25,5 +28,11 @@ class IndexAccess implements ModifiablePrimary {
     return (drawDepth('${prefix}IndexAccess', depth) +
         (this.index?.toString(depth: depth + 1, prefix: 'index: ') ?? '') +
         (this.object?.toString(depth: depth + 1, prefix: 'object: ') ?? ''));
+  }
+
+  void propagateScopeMark(ScopeElement parentMark) {
+    this.scopeMark = parentMark;
+    this.index.propagateScopeMark(parentMark);
+    this.object.propagateScopeMark(parentMark);
   }
 }

--- a/ast-nodes/index-access.dart
+++ b/ast-nodes/index-access.dart
@@ -1,5 +1,6 @@
 import 'modifiable-primary.dart';
 import 'expression.dart';
+import 'var-type.dart';
 import '../print-utils.dart';
 import '../symbol-table/scope-element.dart';
 
@@ -17,6 +18,8 @@ import '../symbol-table/scope-element.dart';
 /// )
 /// ```
 class IndexAccess implements ModifiablePrimary {
+  VarType resultType;
+  bool isConstant = false;
   ScopeElement scopeMark;
 
   Expression index;

--- a/ast-nodes/index.dart
+++ b/ast-nodes/index.dart
@@ -52,3 +52,4 @@ export 'declaration.dart';
 export 'return-statement.dart';
 export 'pos-operator.dart';
 export 'prioritized.dart';
+export 'scope-creator.dart';

--- a/ast-nodes/integer-literal.dart
+++ b/ast-nodes/integer-literal.dart
@@ -1,9 +1,13 @@
 import 'primary.dart';
+import 'integer-type.dart';
+import 'var-type.dart';
 import '../print-utils.dart';
 import '../symbol-table/scope-element.dart';
 
 /// A literal integer number in code.
 class IntegerLiteral implements Primary {
+  VarType resultType = IntegerType();
+  bool isConstant = true;
   ScopeElement scopeMark;
 
   int value;

--- a/ast-nodes/integer-literal.dart
+++ b/ast-nodes/integer-literal.dart
@@ -21,4 +21,8 @@ class IntegerLiteral implements Primary {
   void propagateScopeMark(ScopeElement parentMark) {
     this.scopeMark = parentMark;
   }
+
+  void checkSemantics() {
+    // TODO: implement
+  }
 }

--- a/ast-nodes/integer-literal.dart
+++ b/ast-nodes/integer-literal.dart
@@ -1,13 +1,20 @@
 import 'primary.dart';
 import '../print-utils.dart';
+import '../symbol-table/scope-element.dart';
 
 /// A literal integer number in code.
 class IntegerLiteral implements Primary {
+  ScopeElement scopeMark;
+
   int value;
 
   IntegerLiteral(this.value);
 
   String toString({int depth = 0, String prefix = ''}) {
     return drawDepth('${prefix}IntegerLiteral(${this.value})', depth);
+  }
+
+  void propagateScopeMark(ScopeElement parentMark) {
+    this.scopeMark = parentMark;
   }
 }

--- a/ast-nodes/integer-type.dart
+++ b/ast-nodes/integer-type.dart
@@ -15,4 +15,6 @@ class IntegerType implements VarType {
   void propagateScopeMark(ScopeElement parentMark) {
     this.scopeMark = parentMark;
   }
+
+  void checkSemantics() {}
 }

--- a/ast-nodes/integer-type.dart
+++ b/ast-nodes/integer-type.dart
@@ -1,11 +1,18 @@
 import 'var-type.dart';
 import '../print-utils.dart';
+import '../symbol-table/scope-element.dart';
 
 /// The built-in integer type.
 class IntegerType implements VarType {
+  ScopeElement scopeMark;
+
   IntegerType();
 
   String toString({int depth = 0, String prefix = ''}) {
     return drawDepth('${prefix}IntegerType', depth);
+  }
+
+  void propagateScopeMark(ScopeElement parentMark) {
+    this.scopeMark = parentMark;
   }
 }

--- a/ast-nodes/less-eq-operator.dart
+++ b/ast-nodes/less-eq-operator.dart
@@ -13,4 +13,8 @@ class LessEqOperator extends BinaryRelation implements Comparison {
 
   LessEqOperator(Expression leftOperand, Expression rightOperand)
     : super(leftOperand, rightOperand);
+
+  void checkSemantics() {
+    // TODO: implement
+  }
 }

--- a/ast-nodes/less-eq-operator.dart
+++ b/ast-nodes/less-eq-operator.dart
@@ -1,11 +1,16 @@
 import 'comparison.dart';
 import 'binary-relation.dart';
 import 'expression.dart';
+import 'boolean-type.dart';
+import 'var-type.dart';
 
 /// Numeric _less than or equal to_ operator.
 ///
 /// Casts both operands to a numeric type and returns a boolean value.
 class LessEqOperator extends BinaryRelation implements Comparison {
+  VarType resultType = BooleanType();
+  bool isConstant;
+
   LessEqOperator(Expression leftOperand, Expression rightOperand)
     : super(leftOperand, rightOperand);
 }

--- a/ast-nodes/less-operator.dart
+++ b/ast-nodes/less-operator.dart
@@ -1,11 +1,16 @@
 import 'comparison.dart';
 import 'binary-relation.dart';
 import 'expression.dart';
+import 'boolean-type.dart';
+import 'var-type.dart';
 
 /// Numeric _less than_ operator.
 ///
 /// Casts both operands to a numeric type and returns a boolean value.
 class LessOperator extends BinaryRelation implements Comparison {
+  VarType resultType = BooleanType();
+  bool isConstant;
+
   LessOperator(Expression leftOperand, Expression rightOperand)
     : super(leftOperand, rightOperand);
 }

--- a/ast-nodes/less-operator.dart
+++ b/ast-nodes/less-operator.dart
@@ -13,4 +13,8 @@ class LessOperator extends BinaryRelation implements Comparison {
 
   LessOperator(Expression leftOperand, Expression rightOperand)
     : super(leftOperand, rightOperand);
+
+  void checkSemantics() {
+    // TODO: implement
+  }
 }

--- a/ast-nodes/mod-operator.dart
+++ b/ast-nodes/mod-operator.dart
@@ -12,4 +12,8 @@ class ModOperator extends BinaryRelation implements Product {
 
   ModOperator(Expression leftOperand, Expression rightOperand)
     : super(leftOperand, rightOperand);
+
+  void checkSemantics() {
+    // TODO: implement
+  }
 }

--- a/ast-nodes/mod-operator.dart
+++ b/ast-nodes/mod-operator.dart
@@ -1,11 +1,15 @@
 import 'product.dart';
 import 'binary-relation.dart';
 import 'expression.dart';
+import 'var-type.dart';
 
 /// Numeric modulo operator.
 ///
 /// Casts both operands to a numeric type and returns a numeric value.
 class ModOperator extends BinaryRelation implements Product {
+  VarType resultType;
+  bool isConstant;
+
   ModOperator(Expression leftOperand, Expression rightOperand)
     : super(leftOperand, rightOperand);
 }

--- a/ast-nodes/mul-operator.dart
+++ b/ast-nodes/mul-operator.dart
@@ -12,4 +12,8 @@ class MulOperator extends BinaryRelation implements Product {
 
   MulOperator(Expression leftOperand, Expression rightOperand)
     : super(leftOperand, rightOperand);
+
+  void checkSemantics() {
+    // TODO: implement
+  }
 }

--- a/ast-nodes/mul-operator.dart
+++ b/ast-nodes/mul-operator.dart
@@ -1,11 +1,15 @@
 import 'product.dart';
 import 'binary-relation.dart';
 import 'expression.dart';
+import 'var-type.dart';
 
 /// Numeric multiplication operator.
 ///
 /// Casts both operands to a numeric type and returns a numeric value.
 class MulOperator extends BinaryRelation implements Product {
+  VarType resultType;
+  bool isConstant;
+
   MulOperator(Expression leftOperand, Expression rightOperand)
     : super(leftOperand, rightOperand);
 }

--- a/ast-nodes/named-type.dart
+++ b/ast-nodes/named-type.dart
@@ -1,6 +1,7 @@
 import 'var-type.dart';
 import 'type-declaration.dart';
 import '../print-utils.dart';
+import '../semantic-error.dart';
 import '../symbol-table/scope-element.dart';
 
 /// A type that was specified by the [name].
@@ -19,5 +20,14 @@ class NamedType implements VarType {
 
   void propagateScopeMark(ScopeElement parentMark) {
     this.scopeMark = parentMark;
+  }
+
+  void checkSemantics() {
+    var declaration = this.scopeMark.resolve(this.name);
+    if (declaration == null) {
+      throw SemanticError(this, "'$name' is not defined");
+    } else if (declaration is! TypeDeclaration) {
+      throw SemanticError(this, "'$name' is not a valid type in this scope");
+    }
   }
 }

--- a/ast-nodes/named-type.dart
+++ b/ast-nodes/named-type.dart
@@ -1,16 +1,23 @@
 import 'var-type.dart';
 import 'type-declaration.dart';
 import '../print-utils.dart';
+import '../symbol-table/scope-element.dart';
 
 /// A type that was specified by the [name].
 ///
 /// Refers to custom types declared with [TypeDeclaration]s.
 class NamedType implements VarType {
+  ScopeElement scopeMark;
+
   String name;
 
   NamedType(this.name);
 
   String toString({int depth = 0, String prefix = ''}) {
     return drawDepth('${prefix}NamedType("${this.name}")', depth);
+  }
+
+  void propagateScopeMark(ScopeElement parentMark) {
+    this.scopeMark = parentMark;
   }
 }

--- a/ast-nodes/neg-operator.dart
+++ b/ast-nodes/neg-operator.dart
@@ -11,4 +11,8 @@ class NegOperator extends UnaryRelation implements Primary {
   bool isConstant;
 
   NegOperator(Expression operand) : super(operand);
+
+  void checkSemantics() {
+    // TODO: implement
+  }
 }

--- a/ast-nodes/neg-operator.dart
+++ b/ast-nodes/neg-operator.dart
@@ -1,10 +1,14 @@
 import 'primary.dart';
 import 'unary-relation.dart';
 import 'expression.dart';
+import 'var-type.dart';
 
 /// Numeric negation operator.
 ///
 /// Casts the operand to a numeric type and returns a numeric value.
 class NegOperator extends UnaryRelation implements Primary {
+  VarType resultType;
+  bool isConstant;
+
   NegOperator(Expression operand) : super(operand);
 }

--- a/ast-nodes/neq-operator.dart
+++ b/ast-nodes/neq-operator.dart
@@ -1,11 +1,16 @@
 import 'comparison.dart';
 import 'binary-relation.dart';
 import 'expression.dart';
+import 'boolean-type.dart';
+import 'var-type.dart';
 
 /// Universal _not equal to_ operator.
 ///
 /// Requires both operands to be of the same type.
 class NeqOperator extends BinaryRelation implements Comparison {
+  VarType resultType = BooleanType();
+  bool isConstant;
+
   NeqOperator(Expression leftOperand, Expression rightOperand)
     : super(leftOperand, rightOperand);
 }

--- a/ast-nodes/neq-operator.dart
+++ b/ast-nodes/neq-operator.dart
@@ -13,4 +13,8 @@ class NeqOperator extends BinaryRelation implements Comparison {
 
   NeqOperator(Expression leftOperand, Expression rightOperand)
     : super(leftOperand, rightOperand);
+
+  void checkSemantics() {
+    // TODO: implement
+  }
 }

--- a/ast-nodes/node.dart
+++ b/ast-nodes/node.dart
@@ -1,12 +1,16 @@
 import '../lexer.dart';
 import '../syntax-error.dart';
+import '../symbol-table/scope-element.dart';
 
 /// An abstract node of the AST.
 abstract class Node {
+  ScopeElement scopeMark;
   /// Construct the node from the given [tokens].
   ///
   /// Expected to throw [SyntaxError] on failure.
   Node.parse(Iterable<Token> tokens);
 
   String toString({int depth = 0, String prefix = ''});
+
+  void propagateScopeMark(ScopeElement parentMark);
 }

--- a/ast-nodes/node.dart
+++ b/ast-nodes/node.dart
@@ -13,4 +13,6 @@ abstract class Node {
   String toString({int depth = 0, String prefix = ''});
 
   void propagateScopeMark(ScopeElement parentMark);
+
+  void checkSemantics();
 }

--- a/ast-nodes/not-operator.dart
+++ b/ast-nodes/not-operator.dart
@@ -1,9 +1,14 @@
 import 'unary-relation.dart';
 import 'expression.dart';
+import 'boolean-type.dart';
+import 'var-type.dart';
 
 /// Logical NOT operator.
 ///
 /// Casts the [operand] to `boolean` and returns a `boolean` value.
 class NotOperator extends UnaryRelation {
+  VarType resultType = BooleanType();
+  bool isConstant;
+
   NotOperator(Expression operand) : super(operand);
 }

--- a/ast-nodes/not-operator.dart
+++ b/ast-nodes/not-operator.dart
@@ -11,4 +11,8 @@ class NotOperator extends UnaryRelation {
   bool isConstant;
 
   NotOperator(Expression operand) : super(operand);
+
+  void checkSemantics() {
+    // TODO: implement
+  }
 }

--- a/ast-nodes/or-operator.dart
+++ b/ast-nodes/or-operator.dart
@@ -1,10 +1,15 @@
 import 'binary-relation.dart';
 import 'expression.dart';
+import 'boolean-type.dart';
+import 'var-type.dart';
 
 /// Logical OR operator.
 ///
 /// Casts both operands to `boolean` and returns a `boolean` value.
 class OrOperator extends BinaryRelation {
+  VarType resultType = BooleanType();
+  bool isConstant;
+
   OrOperator(Expression leftOperand, Expression rightOperand)
     : super(leftOperand, rightOperand);
 }

--- a/ast-nodes/or-operator.dart
+++ b/ast-nodes/or-operator.dart
@@ -12,4 +12,8 @@ class OrOperator extends BinaryRelation {
 
   OrOperator(Expression leftOperand, Expression rightOperand)
     : super(leftOperand, rightOperand);
+
+  void checkSemantics() {
+    // TODO: implement
+  }
 }

--- a/ast-nodes/parameter.dart
+++ b/ast-nodes/parameter.dart
@@ -45,4 +45,8 @@ class Parameter implements Node {
     this.scopeMark = parentMark;
     this.type.propagateScopeMark(parentMark);
   }
+
+  void checkSemantics() {
+    // TODO: implement
+  }
 }

--- a/ast-nodes/parameter.dart
+++ b/ast-nodes/parameter.dart
@@ -1,13 +1,17 @@
 import 'node.dart';
 import 'var-type.dart';
+import 'variable-declaration.dart';
 import '../print-utils.dart';
 import '../parser-utils.dart';
 import '../syntax-error.dart';
 import '../lexer.dart';
 import '../iterator-utils.dart';
+import '../symbol-table/scope-element.dart';
 
 /// A routine parameter, characterized by the [name] and the [type].
 class Parameter implements Node {
+  ScopeElement scopeMark;
+
   String name;
   VarType type;
 
@@ -26,10 +30,19 @@ class Parameter implements Node {
     return Parameter(nameBuffer, VarType.parse(consumeFull(iter)));
   }
 
+  VariableDeclaration toDeclaration() {
+    return VariableDeclaration(this.name, this.type, null);
+  }
+
   String toString({int depth = 0, String prefix = ''}) {
     return (
       drawDepth('${prefix}Parameter("${this.name}")', depth)
       + (this.type?.toString(depth: depth + 1, prefix: 'type: ') ?? '')
     );
+  }
+
+  void propagateScopeMark(ScopeElement parentMark) {
+    this.scopeMark = parentMark;
+    this.type.propagateScopeMark(parentMark);
   }
 }

--- a/ast-nodes/pos-operator.dart
+++ b/ast-nodes/pos-operator.dart
@@ -11,4 +11,8 @@ class PosOperator extends UnaryRelation implements Primary {
   bool isConstant;
 
   PosOperator(Expression operand) : super(operand);
+
+  void checkSemantics() {
+    // TODO: implement
+  }
 }

--- a/ast-nodes/pos-operator.dart
+++ b/ast-nodes/pos-operator.dart
@@ -1,10 +1,14 @@
 import 'primary.dart';
 import 'unary-relation.dart';
 import 'expression.dart';
+import 'var-type.dart';
 
 /// Numeric unary plus operator.
 ///
 /// Casts the operand to a numeric type and returns a numeric value.
 class PosOperator extends UnaryRelation implements Primary {
+  VarType resultType;
+  bool isConstant;
+
   PosOperator(Expression operand) : super(operand);
 }

--- a/ast-nodes/prioritized.dart
+++ b/ast-nodes/prioritized.dart
@@ -43,4 +43,8 @@ class Prioritized implements Product {
     this.scopeMark = parentMark;
     this.operand.propagateScopeMark(parentMark);
   }
+
+  void checkSemantics() {
+    // TODO: implement
+  }
 }

--- a/ast-nodes/prioritized.dart
+++ b/ast-nodes/prioritized.dart
@@ -1,5 +1,6 @@
 import 'product.dart';
 import 'expression.dart';
+import 'var-type.dart';
 import '../lexer.dart';
 import '../iterator-utils.dart';
 import '../print-utils.dart';
@@ -7,6 +8,8 @@ import '../symbol-table/scope-element.dart';
 
 /// A prioritized expression.
 class Prioritized implements Product {
+  VarType resultType;
+  bool isConstant;
   ScopeElement scopeMark;
 
   Expression operand;

--- a/ast-nodes/prioritized.dart
+++ b/ast-nodes/prioritized.dart
@@ -3,9 +3,12 @@ import 'expression.dart';
 import '../lexer.dart';
 import '../iterator-utils.dart';
 import '../print-utils.dart';
+import '../symbol-table/scope-element.dart';
 
 /// A prioritized expression.
 class Prioritized implements Product {
+  ScopeElement scopeMark;
+
   Expression operand;
 
   Prioritized(this.operand);
@@ -31,5 +34,10 @@ class Prioritized implements Product {
       drawDepth('${prefix}Prioritized', depth)
       + (this.operand?.toString(depth: depth + 1) ?? '')
     );
+  }
+
+  void propagateScopeMark(ScopeElement parentMark) {
+    this.scopeMark = parentMark;
+    this.operand.propagateScopeMark(parentMark);
   }
 }

--- a/ast-nodes/program.dart
+++ b/ast-nodes/program.dart
@@ -96,8 +96,9 @@ class Program implements Node, ScopeCreator {
             .join(''));
   }
 
-  void buildSymbolTable() {
+  Scope buildSymbolTable() {
     this.propagateScopeMark(null);
+    return this.scopes[0];
   }
 
   void propagateScopeMark(ScopeElement parentMark) {

--- a/ast-nodes/program.dart
+++ b/ast-nodes/program.dart
@@ -116,4 +116,8 @@ class Program implements Node, ScopeCreator {
       }
     }
   }
+
+  void checkSemantics() {
+    // TODO: implement
+  }
 }

--- a/ast-nodes/program.dart
+++ b/ast-nodes/program.dart
@@ -3,10 +3,13 @@ import 'declaration.dart';
 import 'variable-declaration.dart';
 import 'type-declaration.dart';
 import 'routine-declaration.dart';
+import 'scope-creator.dart';
 import '../lexer.dart';
 import '../iterator-utils.dart';
 import '../print-utils.dart';
 import '../syntax-error.dart';
+import '../symbol-table/scope.dart';
+import '../symbol-table/scope-element.dart';
 
 /// A program is a list of [Declaration]s.
 ///
@@ -14,7 +17,10 @@ import '../syntax-error.dart';
 ///  - [VariableDeclaration]s
 ///  - [TypeDeclaration]s
 ///  - [RoutineDeclaration]s
-class Program implements Node {
+class Program implements Node, ScopeCreator {
+  ScopeElement scopeMark;
+  List<Scope> scopes;
+
   List<Declaration> declarations;
 
   Program(this.declarations);
@@ -88,5 +94,26 @@ class Program implements Node {
             .declarations
             .map((node) => node?.toString(depth: depth + 2) ?? '')
             .join(''));
+  }
+
+  void buildSymbolTable() {
+    this.propagateScopeMark(null);
+  }
+
+  void propagateScopeMark(ScopeElement parentMark) {
+    var scope = Scope();
+    this.scopes = [scope];
+    ScopeElement currentMark = scope.lastChild;
+
+    for (var declaration in this.declarations) {
+      declaration.propagateScopeMark(currentMark);
+      currentMark = scope.addDeclaration(declaration);
+
+      if (declaration is ScopeCreator) {
+        (declaration as ScopeCreator).scopes.forEach(
+          (subscope) => scope.addSubscope(subscope)
+        );
+      }
+    }
   }
 }

--- a/ast-nodes/range.dart
+++ b/ast-nodes/range.dart
@@ -4,9 +4,12 @@ import 'expression.dart';
 import '../print-utils.dart';
 import '../iterator-utils.dart';
 import '../lexer.dart';
+import '../symbol-table/scope-element.dart';
 
 /// An iteration range for the `for` loop.
 class Range implements Node {
+  ScopeElement scopeMark;
+
   Expression start;
   Expression end;
 
@@ -30,5 +33,11 @@ class Range implements Node {
     return (drawDepth('${prefix}Range', depth) +
         (this.start?.toString(depth: depth + 1, prefix: 'start: ') ?? '') +
         (this.end?.toString(depth: depth + 1, prefix: 'end: ') ?? ''));
+  }
+
+  void propagateScopeMark(ScopeElement parentMark) {
+    this.scopeMark = parentMark;
+    this.start.propagateScopeMark(parentMark);
+    this.end.propagateScopeMark(parentMark);
   }
 }

--- a/ast-nodes/range.dart
+++ b/ast-nodes/range.dart
@@ -40,4 +40,8 @@ class Range implements Node {
     this.start.propagateScopeMark(parentMark);
     this.end.propagateScopeMark(parentMark);
   }
+
+  void checkSemantics() {
+    // TODO: implement
+  }
 }

--- a/ast-nodes/real-literal.dart
+++ b/ast-nodes/real-literal.dart
@@ -1,13 +1,20 @@
 import 'primary.dart';
 import '../print-utils.dart';
+import '../symbol-table/scope-element.dart';
 
 /// A literal floating-point number in code.
 class RealLiteral implements Primary {
+  ScopeElement scopeMark;
+
   double value;
 
   RealLiteral(this.value);
 
   String toString({int depth = 0, String prefix = ''}) {
     return drawDepth('${prefix}RealLiteral(${this.value})', depth);
+  }
+
+  void propagateScopeMark(ScopeElement parentMark) {
+    this.scopeMark = parentMark;
   }
 }

--- a/ast-nodes/real-literal.dart
+++ b/ast-nodes/real-literal.dart
@@ -1,9 +1,13 @@
 import 'primary.dart';
+import 'real-type.dart';
+import 'var-type.dart';
 import '../print-utils.dart';
 import '../symbol-table/scope-element.dart';
 
 /// A literal floating-point number in code.
 class RealLiteral implements Primary {
+  VarType resultType = RealType();
+  bool isConstant = true;
   ScopeElement scopeMark;
 
   double value;

--- a/ast-nodes/real-literal.dart
+++ b/ast-nodes/real-literal.dart
@@ -21,4 +21,8 @@ class RealLiteral implements Primary {
   void propagateScopeMark(ScopeElement parentMark) {
     this.scopeMark = parentMark;
   }
+
+  void checkSemantics() {
+    // TODO: implement
+  }
 }

--- a/ast-nodes/real-type.dart
+++ b/ast-nodes/real-type.dart
@@ -1,11 +1,18 @@
 import 'var-type.dart';
 import '../print-utils.dart';
+import '../symbol-table/scope-element.dart';
 
 /// The built-in real type.
 class RealType implements VarType {
+  ScopeElement scopeMark;
+
   RealType();
 
   String toString({int depth = 0, String prefix = ''}) {
     return drawDepth('${prefix}RealType', depth);
+  }
+
+  void propagateScopeMark(ScopeElement parentMark) {
+    this.scopeMark = parentMark;
   }
 }

--- a/ast-nodes/real-type.dart
+++ b/ast-nodes/real-type.dart
@@ -15,4 +15,6 @@ class RealType implements VarType {
   void propagateScopeMark(ScopeElement parentMark) {
     this.scopeMark = parentMark;
   }
+
+  void checkSemantics() {}
 }

--- a/ast-nodes/record-type.dart
+++ b/ast-nodes/record-type.dart
@@ -73,4 +73,10 @@ class RecordType implements VarType, ScopeCreator {
       currentMark = scope.addDeclaration(field);
     }
   }
+
+  void checkSemantics() {
+    for (var declaration in this.fields) {
+      declaration.checkSemantics();
+    }
+  }
 }

--- a/ast-nodes/record-type.dart
+++ b/ast-nodes/record-type.dart
@@ -1,12 +1,18 @@
 import 'var-type.dart';
 import 'variable-declaration.dart';
+import 'scope-creator.dart';
 import '../lexer.dart';
 import '../syntax-error.dart';
 import '../iterator-utils.dart';
 import '../print-utils.dart';
+import '../symbol-table/scope.dart';
+import '../symbol-table/scope-element.dart';
 
 /// A compound type that has several [fields] inside.
-class RecordType implements VarType {
+class RecordType implements VarType, ScopeCreator {
+  ScopeElement scopeMark;
+  List<Scope> scopes;
+
   List<VariableDeclaration> fields;
 
   RecordType(this.fields);
@@ -53,5 +59,18 @@ class RecordType implements VarType {
       + drawDepth('fields:', depth + 1)
       + this.fields.map((node) => node?.toString(depth: depth + 2) ?? '').join('')
     );
+  }
+
+  void propagateScopeMark(ScopeElement parentMark) {
+    this.scopeMark = parentMark;
+
+    var scope = Scope();
+    this.scopes = [scope];
+    ScopeElement currentMark = scope.lastChild;
+
+    for (var field in this.fields) {
+      field.propagateScopeMark(currentMark);
+      currentMark = scope.addDeclaration(field);
+    }
   }
 }

--- a/ast-nodes/return-statement.dart
+++ b/ast-nodes/return-statement.dart
@@ -3,9 +3,12 @@ import 'expression.dart';
 import '../print-utils.dart';
 import '../iterator-utils.dart';
 import '../lexer.dart';
+import '../symbol-table/scope-element.dart';
 
 /// A return statement in a function.
 class ReturnStatement implements Statement {
+  ScopeElement scopeMark;
+
   Expression value;
 
   ReturnStatement(this.value);
@@ -22,5 +25,10 @@ class ReturnStatement implements Statement {
       drawDepth('${prefix}ReturnStatement', depth)
       + (this.value?.toString(depth: depth + 1, prefix: 'value: ') ?? '')
     );
+  }
+
+  void propagateScopeMark(ScopeElement parentMark) {
+    this.scopeMark = parentMark;
+    this.value.propagateScopeMark(parentMark);
   }
 }

--- a/ast-nodes/return-statement.dart
+++ b/ast-nodes/return-statement.dart
@@ -16,7 +16,9 @@ class ReturnStatement implements Statement {
   factory ReturnStatement.parse(Iterable<Token> tokens) {
     var iterator = tokens.iterator;
     checkNext(iterator, RegExp('return\$'), "Expected 'return'");
-    iterator.moveNext();
+    if (!iterator.moveNext()) {
+      return ReturnStatement(null);
+    }
     return ReturnStatement(Expression.parse(consumeFull(iterator)));
   }
 
@@ -29,7 +31,7 @@ class ReturnStatement implements Statement {
 
   void propagateScopeMark(ScopeElement parentMark) {
     this.scopeMark = parentMark;
-    this.value.propagateScopeMark(parentMark);
+    this.value?.propagateScopeMark(parentMark);
   }
 
   void checkSemantics() {

--- a/ast-nodes/return-statement.dart
+++ b/ast-nodes/return-statement.dart
@@ -31,4 +31,8 @@ class ReturnStatement implements Statement {
     this.scopeMark = parentMark;
     this.value.propagateScopeMark(parentMark);
   }
+
+  void checkSemantics() {
+    // TODO: implement
+  }
 }

--- a/ast-nodes/routine-call.dart
+++ b/ast-nodes/routine-call.dart
@@ -77,4 +77,8 @@ class RoutineCall implements Primary {
       argument.propagateScopeMark(parentMark);
     }
   }
+
+  void checkSemantics() {
+    // TODO: implement
+  }
 }

--- a/ast-nodes/routine-call.dart
+++ b/ast-nodes/routine-call.dart
@@ -1,14 +1,17 @@
+import 'primary.dart';
+import 'expression.dart';
+import 'var-type.dart';
 import '../iterator-utils.dart';
 import '../lexer.dart';
 import '../parser-utils.dart';
 import '../syntax-error.dart';
-import 'primary.dart';
-import 'expression.dart';
 import '../print-utils.dart';
 import '../symbol-table/scope-element.dart';
 
 /// A routine call by [name], passing zero or more [arguments].
 class RoutineCall implements Primary {
+  VarType resultType;
+  bool isConstant = false;
   ScopeElement scopeMark;
 
   String name;
@@ -71,7 +74,7 @@ class RoutineCall implements Primary {
   void propagateScopeMark(ScopeElement parentMark) {
     this.scopeMark = parentMark;
     for (var argument in arguments) {
-      argument.propagateScopeMark(parentMark);  
+      argument.propagateScopeMark(parentMark);
     }
   }
 }

--- a/ast-nodes/routine-call.dart
+++ b/ast-nodes/routine-call.dart
@@ -5,9 +5,12 @@ import '../syntax-error.dart';
 import 'primary.dart';
 import 'expression.dart';
 import '../print-utils.dart';
+import '../symbol-table/scope-element.dart';
 
 /// A routine call by [name], passing zero or more [arguments].
 class RoutineCall implements Primary {
+  ScopeElement scopeMark;
+
   String name;
   List<Expression> arguments;
 
@@ -63,5 +66,12 @@ class RoutineCall implements Primary {
             .arguments
             .map((node) => node?.toString(depth: depth + 2) ?? '')
             .join(''));
+  }
+
+  void propagateScopeMark(ScopeElement parentMark) {
+    this.scopeMark = parentMark;
+    for (var argument in arguments) {
+      argument.propagateScopeMark(parentMark);  
+    }
   }
 }

--- a/ast-nodes/routine-declaration.dart
+++ b/ast-nodes/routine-declaration.dart
@@ -86,14 +86,15 @@ class RoutineDeclaration extends Declaration implements ScopeCreator {
 
   void propagateScopeMark(ScopeElement parentMark) {
     this.scopeMark = parentMark;
-    for (var parameter in this.parameters) {
-      parameter.propagateScopeMark(parentMark);
-    }
-    this.returnType.propagateScopeMark(parentMark);
-
     var scope = Scope();
     this.scopes = [scope];
     ScopeElement currentMark = scope.lastChild;
+
+    for (var parameter in this.parameters) {
+      parameter.propagateScopeMark(parentMark);
+      currentMark = scope.addDeclaration(parameter.toDeclaration());
+    }
+    this.returnType?.propagateScopeMark(parentMark);
 
     for (var statement in this.body) {
       statement.propagateScopeMark(currentMark);

--- a/ast-nodes/routine-declaration.dart
+++ b/ast-nodes/routine-declaration.dart
@@ -2,14 +2,20 @@ import 'declaration.dart';
 import 'parameter.dart';
 import 'var-type.dart';
 import 'statement.dart';
+import 'scope-creator.dart';
 import '../lexer.dart';
 import '../print-utils.dart';
 import '../parser-utils.dart';
 import '../iterator-utils.dart';
 import '../syntax-error.dart';
+import '../symbol-table/scope.dart';
+import '../symbol-table/scope-element.dart';
 
 /// A routine declaration has [parameters], a [returnType] and a [body].
-class RoutineDeclaration extends Declaration {
+class RoutineDeclaration extends Declaration implements ScopeCreator {
+  ScopeElement scopeMark;
+  List<Scope> scopes;
+
   List<Parameter> parameters;
   VarType returnType;
   List<Statement> body;
@@ -76,5 +82,30 @@ class RoutineDeclaration extends Declaration {
       + drawDepth('body:', depth + 1)
       + this.body.map((node) => node?.toString(depth: depth + 2) ?? '').join('')
     );
+  }
+
+  void propagateScopeMark(ScopeElement parentMark) {
+    this.scopeMark = parentMark;
+    for (var parameter in this.parameters) {
+      parameter.propagateScopeMark(parentMark);
+    }
+    this.returnType.propagateScopeMark(parentMark);
+
+    var scope = Scope();
+    this.scopes = [scope];
+    ScopeElement currentMark = scope.lastChild;
+
+    for (var statement in this.body) {
+      statement.propagateScopeMark(currentMark);
+      if (statement is Declaration) {
+        currentMark = scope.addDeclaration(statement);
+      }
+
+      if (statement is ScopeCreator) {
+        (statement as ScopeCreator).scopes.forEach(
+          (subscope) => scope.addSubscope(subscope)
+        );
+      }
+    }
   }
 }

--- a/ast-nodes/routine-declaration.dart
+++ b/ast-nodes/routine-declaration.dart
@@ -108,4 +108,18 @@ class RoutineDeclaration extends Declaration implements ScopeCreator {
       }
     }
   }
+
+  void checkSemantics() {
+    this.scopeMark.ensureNoOther(this.name);
+
+    for (var parameter in this.parameters) {
+      parameter.checkSemantics();
+    }
+
+    this.returnType.checkSemantics();
+
+    for (var statement in this.body) {
+      statement.checkSemantics();
+    }
+  }
 }

--- a/ast-nodes/scope-creator.dart
+++ b/ast-nodes/scope-creator.dart
@@ -1,0 +1,5 @@
+import '../symbol-table/scope.dart';
+
+abstract class ScopeCreator {
+  List<Scope> scopes;
+}

--- a/ast-nodes/sub-operator.dart
+++ b/ast-nodes/sub-operator.dart
@@ -12,4 +12,8 @@ class SubOperator extends BinaryRelation implements Sum {
 
   SubOperator(Expression leftOperand, Expression rightOperand)
     : super(leftOperand, rightOperand);
+
+  void checkSemantics() {
+    // TODO: implement
+  }
 }

--- a/ast-nodes/sub-operator.dart
+++ b/ast-nodes/sub-operator.dart
@@ -1,11 +1,15 @@
 import 'sum.dart';
 import 'binary-relation.dart';
 import 'expression.dart';
+import 'var-type.dart';
 
 /// Numeric subtraction operator.
 ///
 /// Casts both operands to a numeric type and returns a numeric value.
 class SubOperator extends BinaryRelation implements Sum {
+  VarType resultType;
+  bool isConstant;
+
   SubOperator(Expression leftOperand, Expression rightOperand)
     : super(leftOperand, rightOperand);
 }

--- a/ast-nodes/type-declaration.dart
+++ b/ast-nodes/type-declaration.dart
@@ -41,4 +41,8 @@ class TypeDeclaration extends Declaration {
     this.scopeMark = parentMark;
     this.value.propagateScopeMark(parentMark);
   }
+
+  void checkSemantics() {
+    // TODO: implement
+  }
 }

--- a/ast-nodes/type-declaration.dart
+++ b/ast-nodes/type-declaration.dart
@@ -5,9 +5,12 @@ import '../syntax-error.dart';
 import '../iterator-utils.dart';
 import '../parser-utils.dart';
 import '../print-utils.dart';
+import '../symbol-table/scope-element.dart';
 
 /// A type declaration gives a name to some type [value].
 class TypeDeclaration extends Declaration {
+  ScopeElement scopeMark;
+
   VarType value;
 
   TypeDeclaration(name, this.value) : super(name);
@@ -32,5 +35,10 @@ class TypeDeclaration extends Declaration {
       drawDepth('${prefix}TypeDeclaration("${this.name}")', depth)
       + (this.value?.toString(depth: depth + 1) ?? '')
     );
+  }
+
+  void propagateScopeMark(ScopeElement parentMark) {
+    this.scopeMark = parentMark;
+    this.value.propagateScopeMark(parentMark);
   }
 }

--- a/ast-nodes/unary-relation.dart
+++ b/ast-nodes/unary-relation.dart
@@ -1,8 +1,11 @@
 import 'expression.dart';
 import '../print-utils.dart';
+import '../symbol-table/scope-element.dart';
 
 /// An abstract unary relation with one [operand].
 abstract class UnaryRelation implements Expression {
+  ScopeElement scopeMark;
+
   Expression operand;
 
   UnaryRelation(this.operand);
@@ -12,5 +15,10 @@ abstract class UnaryRelation implements Expression {
       drawDepth(prefix + this.runtimeType.toString(), depth)
       + (this.operand?.toString(depth: depth + 1) ?? '')
     );
+  }
+
+  void propagateScopeMark(ScopeElement parentMark) {
+    this.scopeMark = parentMark;
+    this.operand.propagateScopeMark(parentMark);
   }
 }

--- a/ast-nodes/variable-declaration.dart
+++ b/ast-nodes/variable-declaration.dart
@@ -6,11 +6,14 @@ import 'var-type.dart';
 import 'expression.dart';
 import '../lexer.dart';
 import '../print-utils.dart';
+import '../symbol-table/scope-element.dart';
 
 /// A variable declaration contains a [type] and the initial [value].
 ///
 /// Both of these can be set to [null].
 class VariableDeclaration extends Declaration {
+  ScopeElement scopeMark;
+
   VarType type;
   Expression value;
 
@@ -55,5 +58,11 @@ class VariableDeclaration extends Declaration {
     return (drawDepth('${prefix}VariableDeclaration("${this.name}")', depth) +
         (this.type?.toString(depth: depth + 1, prefix: 'type: ') ?? '') +
         (this.value?.toString(depth: depth + 1, prefix: 'value: ') ?? ''));
+  }
+
+  void propagateScopeMark(ScopeElement parentMark) {
+    this.scopeMark = parentMark;
+    this.type.propagateScopeMark(parentMark);
+    this.value.propagateScopeMark(parentMark);
   }
 }

--- a/ast-nodes/variable-declaration.dart
+++ b/ast-nodes/variable-declaration.dart
@@ -65,4 +65,8 @@ class VariableDeclaration extends Declaration {
     this.type.propagateScopeMark(parentMark);
     this.value.propagateScopeMark(parentMark);
   }
+
+  void checkSemantics() {
+    // TODO: implement
+  }
 }

--- a/ast-nodes/variable-declaration.dart
+++ b/ast-nodes/variable-declaration.dart
@@ -62,8 +62,8 @@ class VariableDeclaration extends Declaration {
 
   void propagateScopeMark(ScopeElement parentMark) {
     this.scopeMark = parentMark;
-    this.type.propagateScopeMark(parentMark);
-    this.value.propagateScopeMark(parentMark);
+    this.type?.propagateScopeMark(parentMark);
+    this.value?.propagateScopeMark(parentMark);
   }
 
   void checkSemantics() {

--- a/ast-nodes/variable.dart
+++ b/ast-nodes/variable.dart
@@ -20,4 +20,8 @@ class Variable implements ModifiablePrimary {
   void propagateScopeMark(ScopeElement parentMark) {
     this.scopeMark = parentMark;
   }
+
+  void checkSemantics() {
+    // TODO: implement
+  }
 }

--- a/ast-nodes/variable.dart
+++ b/ast-nodes/variable.dart
@@ -1,9 +1,12 @@
 import 'modifiable-primary.dart';
+import 'var-type.dart';
 import '../print-utils.dart';
 import '../symbol-table/scope-element.dart';
 
 /// A variable reference by [name] – for either reading or writing.
 class Variable implements ModifiablePrimary {
+  VarType resultType;
+  bool isConstant = false;
   ScopeElement scopeMark;
 
   String name;

--- a/ast-nodes/variable.dart
+++ b/ast-nodes/variable.dart
@@ -1,13 +1,20 @@
 import 'modifiable-primary.dart';
 import '../print-utils.dart';
+import '../symbol-table/scope-element.dart';
 
 /// A variable reference by [name] – for either reading or writing.
 class Variable implements ModifiablePrimary {
+  ScopeElement scopeMark;
+
   String name;
 
   Variable(this.name);
 
   String toString({int depth = 0, String prefix = ''}) {
     return drawDepth('${prefix}Variable("${this.name}")', depth);
+  }
+
+  void propagateScopeMark(ScopeElement parentMark) {
+    this.scopeMark = parentMark;
   }
 }

--- a/ast-nodes/while-loop.dart
+++ b/ast-nodes/while-loop.dart
@@ -76,4 +76,8 @@ class WhileLoop implements Statement, ScopeCreator {
       }
     }
   }
+
+  void checkSemantics() {
+    // TODO: implement
+  }
 }

--- a/ast-nodes/xor-operator.dart
+++ b/ast-nodes/xor-operator.dart
@@ -1,10 +1,15 @@
 import 'binary-relation.dart';
 import 'expression.dart';
+import 'boolean-type.dart';
+import 'var-type.dart';
 
 /// Logical XOR operator.
 ///
 /// Casts both operands to `boolean` and returns a `boolean` value.
 class XorOperator extends BinaryRelation {
+  VarType resultType = BooleanType();
+  bool isConstant;
+
   XorOperator(Expression leftOperand, Expression rightOperand)
     : super(leftOperand, rightOperand);
 }

--- a/ast-nodes/xor-operator.dart
+++ b/ast-nodes/xor-operator.dart
@@ -12,4 +12,8 @@ class XorOperator extends BinaryRelation {
 
   XorOperator(Expression leftOperand, Expression rightOperand)
     : super(leftOperand, rightOperand);
+
+  void checkSemantics() {
+    // TODO: implement
+  }
 }

--- a/main.dart
+++ b/main.dart
@@ -3,10 +3,20 @@ import 'lexer.dart';
 import 'syntax-error.dart';
 import 'ast-nodes/index.dart';
 
-void main() {
+void main(List<String> args) {
+  File sourceFile;
   try {
-    var tokens = splitToTokens(File('./tests/while.isc').readAsStringSync());
-    print(Program.parse(tokens));
+    sourceFile = File(args.length == 1 ? args[0] : './tests/arithmetic.isc');
+  } on FileSystemException {
+    print("The source file '${args[0]}' couldn't be found.");
+    return;
+  }
+
+  try {
+    var tokens = splitToTokens(sourceFile.readAsStringSync());
+    var programAST = Program.parse(tokens);
+    var symbolTable = programAST.buildSymbolTable();
+    print(symbolTable);
   } on SyntaxError catch (e) {
     print(e);
   }

--- a/semantic-error.dart
+++ b/semantic-error.dart
@@ -1,0 +1,15 @@
+import 'ast-nodes/node.dart';
+
+/// A semantic error in the AST.
+///
+/// Uses the [faultyNode] to give a helpful error message.
+class SemanticError implements Exception {
+  String cause;
+  Node faultyNode;
+
+  SemanticError(this.faultyNode, this.cause);
+
+  String toString() {
+    return this.cause;
+  }
+}

--- a/symbol-table/scope-declaration.dart
+++ b/symbol-table/scope-declaration.dart
@@ -1,0 +1,11 @@
+import 'scope-element.dart';
+import '../ast-nodes/declaration.dart';
+
+/// An object declaration in some scope.
+///
+/// Instances of this class are the main objects of scope chains.
+class ScopeDeclaration extends ScopeElement {
+  Declaration declaration;
+
+  ScopeDeclaration(this.declaration);
+}

--- a/symbol-table/scope-declaration.dart
+++ b/symbol-table/scope-declaration.dart
@@ -1,5 +1,6 @@
 import 'scope-element.dart';
 import '../ast-nodes/declaration.dart';
+import '../print-utils.dart';
 
 /// An object declaration in some scope.
 ///
@@ -8,4 +9,8 @@ class ScopeDeclaration extends ScopeElement {
   Declaration declaration;
 
   ScopeDeclaration(this.declaration);
+
+  String toString({int depth = 0}) {
+    return drawDepth("Declaration '${this.declaration.name}'", depth);
+  }
 }

--- a/symbol-table/scope-element.dart
+++ b/symbol-table/scope-element.dart
@@ -31,4 +31,6 @@ abstract class ScopeElement {
 
     return null;
   }
+
+  String toString({int depth = 0});
 }

--- a/symbol-table/scope-element.dart
+++ b/symbol-table/scope-element.dart
@@ -1,6 +1,7 @@
 import 'scope-declaration.dart';
 import 'scope-start.dart';
 import '../semantic-error.dart';
+import '../ast-nodes/declaration.dart';
 
 /// An abstract element in the scope's linked list (scope chain).
 abstract class ScopeElement {
@@ -9,11 +10,25 @@ abstract class ScopeElement {
   /// Ensure that no other declaration in the chain has the same [name].
   void ensureNoOther(String name) {
     var item = this;
-    while (!(item is ScopeStart)) {
+    while (item is! ScopeStart) {
       if (item is ScopeDeclaration && item.declaration.name == name) {
         throw SemanticError(item.declaration, "Another object is declared with the name '$name'");
       }
       item = item.next;
     }
+  }
+
+  Declaration resolve(String name) {
+    ScopeElement item = this;
+    while (item != null) {
+      if (item is ScopeDeclaration && item.declaration.name == name) {
+        return item.declaration;
+      } else if (item is ScopeStart) {
+        item = (item as ScopeStart).parent;
+      }
+      item = item.next;
+    }
+
+    return null;
   }
 }

--- a/symbol-table/scope-element.dart
+++ b/symbol-table/scope-element.dart
@@ -1,0 +1,19 @@
+import 'scope-declaration.dart';
+import 'scope-start.dart';
+import '../semantic-error.dart';
+
+/// An abstract element in the scope's linked list (scope chain).
+abstract class ScopeElement {
+  ScopeElement next;
+
+  /// Ensure that no other declaration in the chain has the same [name].
+  void ensureNoOther(String name) {
+    var item = this;
+    while (!(item is ScopeStart)) {
+      if (item is ScopeDeclaration && item.declaration.name == name) {
+        throw SemanticError(item.declaration, "Another object is declared with the name '$name'");
+      }
+      item = item.next;
+    }
+  }
+}

--- a/symbol-table/scope-start.dart
+++ b/symbol-table/scope-start.dart
@@ -1,0 +1,11 @@
+import 'scope.dart';
+import 'scope-element.dart';
+
+/// The initial element in the [Scope] chain, also its terminating element.
+///
+/// Contains a reference to the [parent] scope to continue traversal.
+class ScopeStart extends ScopeElement {
+  Scope parent;
+
+  ScopeStart(this.parent);
+}

--- a/symbol-table/scope-start.dart
+++ b/symbol-table/scope-start.dart
@@ -8,4 +8,8 @@ class ScopeStart extends ScopeElement {
   Scope parent;
 
   ScopeStart(this.parent);
+
+  String toString({int depth = 0}) {
+    return '';
+  }
 }

--- a/symbol-table/scope.dart
+++ b/symbol-table/scope.dart
@@ -1,0 +1,30 @@
+import 'scope-element.dart';
+import 'scope-declaration.dart';
+import 'scope-start.dart';
+import '../ast-nodes/declaration.dart';
+
+/// The scope of declaring objects.
+///
+/// Built using a linked list of [ScopeElement]s (the scope chain).
+class Scope extends ScopeElement {
+  ScopeElement lastChild;
+
+  Scope() {
+    lastChild = ScopeStart(this);
+  }
+
+  void add(ScopeElement element) {
+    element.next = this.lastChild;
+    this.lastChild = element;
+  }
+
+  ScopeElement addDeclaration(Declaration declaration) {
+    var newElement = ScopeDeclaration(declaration);
+    this.add(newElement);
+    return newElement;
+  }
+
+  void addSubscope(Scope subscope) {
+    this.add(subscope);
+  }
+}

--- a/symbol-table/scope.dart
+++ b/symbol-table/scope.dart
@@ -2,6 +2,7 @@ import 'scope-element.dart';
 import 'scope-declaration.dart';
 import 'scope-start.dart';
 import '../ast-nodes/declaration.dart';
+import '../print-utils.dart';
 
 /// The scope of declaring objects.
 ///
@@ -26,5 +27,19 @@ class Scope extends ScopeElement {
 
   void addSubscope(Scope subscope) {
     this.add(subscope);
+  }
+
+  String toString({int depth = 0}) {
+    var chain = <ScopeElement>[];
+    var item = this.lastChild;
+    while (item is! ScopeStart) {
+      chain.add(item);
+      item = item.next;
+    }
+
+    return (
+      drawDepth('Scope', depth)
+      + chain.reversed.map((node) => node.toString(depth: depth + 1)).join('')
+    );
   }
 }


### PR DESCRIPTION
This PR will bring in the symbol table construction and the necessary interfaces for semantic checking.

Every AST node will implement the `checkSemantics` method that will check the node's semantic correctness and throw a `SemanticError` on violation – just as with `parse` and `SyntaxError`.

The symbol table is implemented as a multi-layer linked list of `ScopeElement`:
* Certain nodes are scope creators (they implement `ScopeCreator`)
* Scope creators have a `scopes` property which is a list of `Scope`s
* `Scope` is a `ScopeElement`, that is, scopes can be elements of that linked list
* The main parts of that linked list are `ScopeDeclaration`s, representing declarations of objects

All in all, we have something like this:
```
Sc
↑
SS ← SD ← SD ← Sc ← SD ← Sc 
               ↑         ↑
               SS ← SD   SS ← SD ← SD 
```
where `Sc` is a scope, `SS` is a scope start (terminal for the linked list), `SD` is a scope declaration

Every node also has a scope mark, which is a pointer to a node in the symbol table. Kind of like a starting point, and to resolve variables, you just go left and up from that starting point. The scope mark is set by the `propagateScopeMark` method recursively.