### PR TITLE
Implement level 2 of code generation

### DIFF
--- a/ast-nodes/expressions/boolean-literal.dart
+++ b/ast-nodes/expressions/boolean-literal.dart
@@ -59,7 +59,10 @@ class BooleanLiteral implements Literal {
   void checkSemantics() {}
 
   Pointer<LLVMOpaqueValue> generateCode(Module module) {
-    // TODO: implement
-    return null;
+    return llvm.LLVMConstInt(
+      this.resultType.getLlvmType(module),
+      this.value ? 1 : 0,
+      0,
+    );
   }
 }

--- a/ast-nodes/expressions/integer-literal.dart
+++ b/ast-nodes/expressions/integer-literal.dart
@@ -69,7 +69,10 @@ class IntegerLiteral implements Literal {
   void checkSemantics() {}
 
   Pointer<LLVMOpaqueValue> generateCode(Module module) {
-    // TODO: implement
-    return null;
+    return llvm.LLVMConstInt(
+      llvm.LLVMInt32TypeInContext(module.context),
+      this.value,
+      1,  // SignExtend: true
+    );
   }
 }

--- a/ast-nodes/expressions/integer-literal.dart
+++ b/ast-nodes/expressions/integer-literal.dart
@@ -70,7 +70,7 @@ class IntegerLiteral implements Literal {
 
   Pointer<LLVMOpaqueValue> generateCode(Module module) {
     return llvm.LLVMConstInt(
-      llvm.LLVMInt32TypeInContext(module.context),
+      this.resultType.getLlvmType(module),
       this.value,
       1,  // SignExtend: true
     );

--- a/ast-nodes/expressions/real-literal.dart
+++ b/ast-nodes/expressions/real-literal.dart
@@ -69,7 +69,9 @@ class RealLiteral implements Literal {
   void checkSemantics() {}
 
   Pointer<LLVMOpaqueValue> generateCode(Module module) {
-    // TODO: implement
-    return null;
+    return llvm.LLVMConstReal(
+      this.resultType.getLlvmType(module),
+      this.value,
+    );
   }
 }

--- a/ast-nodes/return-statement.dart
+++ b/ast-nodes/return-statement.dart
@@ -47,7 +47,14 @@ class ReturnStatement implements Statement {
   }
 
   Pointer<LLVMOpaqueValue> generateCode(Module module) {
-    // TODO: implement
-    return null;
+    var block = llvm.LLVMAppendBasicBlock(module.currentRoutine, MemoryManager.getCString('return'));
+    var builder = llvm.LLVMCreateBuilder();
+    llvm.LLVMPositionBuilderAtEnd(builder, block);
+
+    if (this.value == null) {
+      return llvm.LLVMBuildRetVoid(builder);
+    } else {
+      return llvm.LLVMBuildRet(builder, this.value.generateCode(module));
+    }
   }
 }

--- a/ast-nodes/return-statement.dart
+++ b/ast-nodes/return-statement.dart
@@ -52,9 +52,13 @@ class ReturnStatement implements Statement {
     llvm.LLVMPositionBuilderAtEnd(builder, block);
 
     if (this.value == null) {
-      return llvm.LLVMBuildRetVoid(builder);
+      var code = llvm.LLVMBuildRetVoid(builder);
+      llvm.LLVMDisposeBuilder(builder);
+      return code;
     } else {
-      return llvm.LLVMBuildRet(builder, this.value.generateCode(module));
+      var code = llvm.LLVMBuildRet(builder, this.value.generateCode(module));
+      llvm.LLVMDisposeBuilder(builder);
+      return code;
     }
   }
 }

--- a/ast-nodes/return-statement.dart
+++ b/ast-nodes/return-statement.dart
@@ -48,7 +48,7 @@ class ReturnStatement implements Statement {
 
   Pointer<LLVMOpaqueValue> generateCode(Module module) {
     var block = llvm.LLVMAppendBasicBlock(module.currentRoutine, MemoryManager.getCString('return'));
-    var builder = llvm.LLVMCreateBuilder();
+    var builder = llvm.LLVMCreateBuilderInContext(module.context);
     llvm.LLVMPositionBuilderAtEnd(builder, block);
 
     if (this.value == null) {

--- a/ast-nodes/return-statement.dart
+++ b/ast-nodes/return-statement.dart
@@ -47,7 +47,8 @@ class ReturnStatement implements Statement {
   }
 
   Pointer<LLVMOpaqueValue> generateCode(Module module) {
-    var block = llvm.LLVMAppendBasicBlock(module.currentRoutine, MemoryManager.getCString('return'));
+    var currentRoutine = module.getLastRoutine();
+    var block = llvm.LLVMAppendBasicBlock(currentRoutine, MemoryManager.getCString('return'));
     llvm.LLVMPositionBuilderAtEnd(module.builder, block);
 
     if (this.value == null) {

--- a/ast-nodes/return-statement.dart
+++ b/ast-nodes/return-statement.dart
@@ -48,17 +48,12 @@ class ReturnStatement implements Statement {
 
   Pointer<LLVMOpaqueValue> generateCode(Module module) {
     var block = llvm.LLVMAppendBasicBlock(module.currentRoutine, MemoryManager.getCString('return'));
-    var builder = llvm.LLVMCreateBuilderInContext(module.context);
-    llvm.LLVMPositionBuilderAtEnd(builder, block);
+    llvm.LLVMPositionBuilderAtEnd(module.builder, block);
 
     if (this.value == null) {
-      var code = llvm.LLVMBuildRetVoid(builder);
-      llvm.LLVMDisposeBuilder(builder);
-      return code;
+      return llvm.LLVMBuildRetVoid(module.builder);
     } else {
-      var code = llvm.LLVMBuildRet(builder, this.value.generateCode(module));
-      llvm.LLVMDisposeBuilder(builder);
-      return code;
+      return llvm.LLVMBuildRet(module.builder, this.value.generateCode(module));
     }
   }
 }

--- a/ast-nodes/routine-declaration.dart
+++ b/ast-nodes/routine-declaration.dart
@@ -138,15 +138,20 @@ class RoutineDeclaration extends Declaration implements ScopeCreator {
     var routine = module.addRoutine(
       this.name,
       llvm.LLVMFunctionType(
-        this.returnType.getLlvmType(module),
+        this.returnType?.getLlvmType(module) ?? llvm.LLVMVoidTypeInContext(module.context),
         paramTypes,
         this.parameters.length,
         0,
       )
     );
 
-    // iterate over statements and add basic blocks
+    module.currentRoutine = routine;
 
+    for (var statement in this.body) {
+      statement.generateCode(module);
+    }
+
+    module.currentRoutine = null;
     return routine;
   }
 }

--- a/ast-nodes/routine-declaration.dart
+++ b/ast-nodes/routine-declaration.dart
@@ -145,13 +145,10 @@ class RoutineDeclaration extends Declaration implements ScopeCreator {
       )
     );
 
-    module.currentRoutine = routine;
-
     for (var statement in this.body) {
       statement.generateCode(module);
     }
 
-    module.currentRoutine = null;
     return routine;
   }
 }

--- a/ast-nodes/type-conversion.dart
+++ b/ast-nodes/type-conversion.dart
@@ -35,7 +35,44 @@ class TypeConversion implements Expression {
   }
 
   Pointer<LLVMOpaqueValue> generateCode(Module module) {
-    // TODO: implement
-    return null;
+    // TODO: fix rounding when converting 3.6 to real
+    var srcType = this.expression.resultType.resolve();
+    var dstType = this.resultType;
+
+    if (dstType is RealType) {
+      if (srcType is IntegerType) {
+        return llvm.LLVMBuildSIToFP(
+          module.builder,
+          this.expression.generateCode(module),
+          this.resultType.getLlvmType(module),
+          MemoryManager.getCString('integer->real'),
+        );
+      }
+      if (srcType is BooleanType) {
+        return llvm.LLVMBuildUIToFP(
+          module.builder,
+          this.expression.generateCode(module),
+          this.resultType.getLlvmType(module),
+          MemoryManager.getCString('boolean->real'),
+        );
+      }
+      return null;
+    }
+
+    if (srcType is RealType && dstType is IntegerType) {
+      return llvm.LLVMBuildFPToSI(
+        module.builder,
+        this.expression.generateCode(module),
+        this.resultType.getLlvmType(module),
+        MemoryManager.getCString('real->integer'),
+      );
+    }
+
+    return llvm.LLVMBuildBitCast(
+      module.builder,
+      this.expression.generateCode(module),
+      this.resultType.getLlvmType(module),
+      MemoryManager.getCString('type-conversion'),
+    );
   }
 }

--- a/codegen/module.dart
+++ b/codegen/module.dart
@@ -9,6 +9,7 @@ final llvm = LLVM(DynamicLibrary.open('/usr/lib/libLLVM-10.so'));
 class Module {
   Pointer<LLVMOpaqueContext> context;
   Pointer<LLVMOpaqueModule> _module;
+  Pointer<LLVMOpaqueValue> currentRoutine;
 
   Module(String name) {
     this.context = llvm.LLVMContextCreate();

--- a/codegen/module.dart
+++ b/codegen/module.dart
@@ -8,6 +8,7 @@ final llvm = LLVM(DynamicLibrary.open('/usr/lib/libLLVM-10.so'));
 /// A wrapper around the LLVM Module for easier use.
 class Module {
   Pointer<LLVMOpaqueContext> context;
+  Pointer<LLVMOpaqueBuilder> builder;
   Pointer<LLVMOpaqueModule> _module;
   Pointer<LLVMOpaqueValue> currentRoutine;
 
@@ -17,6 +18,7 @@ class Module {
       MemoryManager.getCString(name),
       this.context,
     );
+    this.builder = llvm.LLVMCreateBuilderInContext(this.context);
   }
 
   Pointer<LLVMOpaqueValue> addRoutine(String name, Pointer<LLVMOpaqueType> type) {
@@ -36,6 +38,7 @@ class Module {
   /// Free the memory occupied by this module.
   void dispose() {
     llvm.LLVMDisposeModule(this._module);
+    llvm.LLVMDisposeBuilder(this.builder);
     llvm.LLVMContextDispose(this.context);
   }
 }

--- a/codegen/module.dart
+++ b/codegen/module.dart
@@ -10,7 +10,6 @@ class Module {
   Pointer<LLVMOpaqueContext> context;
   Pointer<LLVMOpaqueBuilder> builder;
   Pointer<LLVMOpaqueModule> _module;
-  Pointer<LLVMOpaqueValue> currentRoutine;
 
   Module(String name) {
     this.context = llvm.LLVMContextCreate();
@@ -23,6 +22,10 @@ class Module {
 
   Pointer<LLVMOpaqueValue> addRoutine(String name, Pointer<LLVMOpaqueType> type) {
     return llvm.LLVMAddFunction(this._module, MemoryManager.getCString(name), type);
+  }
+
+  Pointer<LLVMOpaqueValue> getLastRoutine() {
+    return llvm.LLVMGetLastFunction(this._module);
   }
 
   /// Get the string representation of the module.

--- a/tests/lvl0.isc
+++ b/tests/lvl0.isc
@@ -1,0 +1,3 @@
+routine main(): integer is
+  return 42;
+end

--- a/tests/lvl1.isc
+++ b/tests/lvl1.isc
@@ -1,0 +1,3 @@
+routine main() is
+  return
+end

--- a/tests/lvl2.isc
+++ b/tests/lvl2.isc
@@ -1,0 +1,27 @@
+routine main1(): real is
+  return false;
+end
+
+routine main2(): real is
+  return true;
+end
+
+routine main3(): integer is
+  return true;
+end
+
+routine main4(): integer is
+  return 3.6;
+end
+
+routine main5(): real is
+  return 3;
+end
+
+routine main6(): real is
+  return true;
+end
+
+routine main7(): real is
+  return false;
+end


### PR DESCRIPTION
Okay, so by now we will be able to create routines that can return literal types and convert between literals. Levels 0, 1 and 2 were the dependencies of many layers, so I wanted to get them done as soon as possible. Now we can start splitting the tasks for other layers.

Note: the type conversion still doesn't follow the spec entirely – we don't do runtime errors and rounding to the nearest integer yet, that will be on higher levels.